### PR TITLE
Edited010

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0'
+        classpath 'com.android.tools.build:gradle:2.1.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -4,12 +4,12 @@ apply plugin: 'com.github.dcendents.android-maven'
 group = 'com.github.douglasjunior'
 
 android {
-    compileSdkVersion 23
+    compileSdkVersion 24
     buildToolsVersion "23.0.3"
 
     defaultConfig {
         minSdkVersion 7
-        targetSdkVersion 23
+        targetSdkVersion 24
         versionCode 2
         versionName "0.0.2"
     }
@@ -39,7 +39,7 @@ buildscript {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:23.2.1'
+    compile 'com.android.support:appcompat-v7:24.0.0'
 }
 
 // build a jar with source files

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -5,7 +5,7 @@ group = 'com.github.douglasjunior'
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "23.0.3"
+    buildToolsVersion "24.0.1"
 
     defaultConfig {
         minSdkVersion 7
@@ -39,7 +39,7 @@ buildscript {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:24.0.0'
+    compile 'com.android.support:appcompat-v7:24.1.0'
 }
 
 // build a jar with source files

--- a/library/src/main/java/io/github/douglasjunior/androidSimpleTooltip/OverlayView.java
+++ b/library/src/main/java/io/github/douglasjunior/androidSimpleTooltip/OverlayView.java
@@ -49,10 +49,12 @@ public class OverlayView extends View {
 
     private View mAnchorView;
     private Bitmap bitmap;
+    private boolean exactRectPortal;
 
-    OverlayView(Context context, View anchorView) {
+    OverlayView(Context context, View anchorView, boolean exactRectPortal) {
         super(context);
         this.mAnchorView = anchorView;
+        this.exactRectPortal = exactRectPortal;
     }
 
     @Override
@@ -82,9 +84,13 @@ public class OverlayView extends View {
         paint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.SRC_OUT));
 
         RectF rect = SimpleTooltipUtils.calculeRectOnScreen(mAnchorView);
-        float offset = getResources().getDimensionPixelSize(mDefaultOverlayCircleOffsetRes);
+        float offset = exactRectPortal ? 0 : getResources().getDimensionPixelSize(mDefaultOverlayCircleOffsetRes);
         rect.set(rect.left - offset, rect.top - offset, rect.right + offset, rect.bottom + offset);
-        osCanvas.drawOval(rect, paint);
+        if (exactRectPortal) {
+            osCanvas.drawRect(rect, paint);
+        } else {
+            osCanvas.drawOval(rect, paint);
+        }
     }
 
     @Override

--- a/library/src/main/java/io/github/douglasjunior/androidSimpleTooltip/SimpleTooltip.java
+++ b/library/src/main/java/io/github/douglasjunior/androidSimpleTooltip/SimpleTooltip.java
@@ -164,6 +164,7 @@ public class SimpleTooltip implements PopupWindow.OnDismissListener {
         rootView.post(new Runnable() {
             @Override
             public void run() {
+                mPopupWindow.setAnimationStyle(R.style.popupAnimation);
                 mPopupWindow.showAtLocation(rootView, Gravity.NO_GRAVITY, rootView.getWidth(), rootView.getHeight());
             }
         });

--- a/library/src/main/java/io/github/douglasjunior/androidSimpleTooltip/SimpleTooltip.java
+++ b/library/src/main/java/io/github/douglasjunior/androidSimpleTooltip/SimpleTooltip.java
@@ -91,7 +91,7 @@ public class SimpleTooltip implements PopupWindow.OnDismissListener {
     private View mContentLayout;
     @IdRes
     private final int mTextViewId;
-    private final String mText;
+    private final CharSequence mText;
     private final View mAnchorView;
     private final boolean mTransparentOverlay;
     private final float mMaxWidth;
@@ -486,7 +486,7 @@ public class SimpleTooltip implements PopupWindow.OnDismissListener {
         private View contentView;
         @IdRes
         private int textViewId = android.R.id.text1;
-        private String text = "";
+        private CharSequence text = "";
         private View anchorView;
         private int gravity = Gravity.BOTTOM;
         private boolean transparentOverlay = true;
@@ -655,7 +655,7 @@ public class SimpleTooltip implements PopupWindow.OnDismissListener {
          * @param text <div class="pt">texto que sera exibido.</div>
          * @return this
          */
-        public Builder text(String text) {
+        public Builder text(CharSequence text) {
             this.text = text;
             return this;
         }

--- a/library/src/main/java/io/github/douglasjunior/androidSimpleTooltip/SimpleTooltip.java
+++ b/library/src/main/java/io/github/douglasjunior/androidSimpleTooltip/SimpleTooltip.java
@@ -42,7 +42,6 @@ import android.support.annotation.DrawableRes;
 import android.support.annotation.IdRes;
 import android.support.annotation.LayoutRes;
 import android.support.v4.content.ContextCompat;
-import android.support.v7.widget.AppCompatPopupWindow;
 import android.support.v7.widget.LinearLayoutCompat;
 import android.view.Gravity;
 import android.view.LayoutInflater;
@@ -82,7 +81,7 @@ public class SimpleTooltip implements PopupWindow.OnDismissListener {
     private final Context mContext;
     private final OnDismissListener mOnDismissListener;
     private final OnShowListener mOnShowListener;
-    private AppCompatPopupWindow mPopupWindow;
+    private PopupWindow mPopupWindow;
     private final int mGravity;
     private final boolean mDismissOnInsideTouch;
     private final boolean mDismissOnOutsideTouch;
@@ -144,7 +143,7 @@ public class SimpleTooltip implements PopupWindow.OnDismissListener {
     }
 
     private void configPopupWindow() {
-        mPopupWindow = new AppCompatPopupWindow(mContext, null, mDefaultPopupWindowStyleRes);
+        mPopupWindow = new PopupWindow(mContext, null, mDefaultPopupWindowStyleRes);
         mPopupWindow.setWidth(ViewGroup.LayoutParams.WRAP_CONTENT);
         mPopupWindow.setHeight(ViewGroup.LayoutParams.WRAP_CONTENT);
         mPopupWindow.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));

--- a/library/src/main/java/io/github/douglasjunior/androidSimpleTooltip/SimpleTooltip.java
+++ b/library/src/main/java/io/github/douglasjunior/androidSimpleTooltip/SimpleTooltip.java
@@ -107,6 +107,7 @@ public class SimpleTooltip implements PopupWindow.OnDismissListener {
     private final long mAnimationDuration;
     private final float mArrowWidth;
     private final float mArrowHeight;
+    private final boolean mExactRectPortal;
     private boolean dismissed = false;
 
     private SimpleTooltip(Builder builder) {
@@ -132,6 +133,7 @@ public class SimpleTooltip implements PopupWindow.OnDismissListener {
         mAnimationDuration = builder.animationDuration;
         mOnDismissListener = builder.onDismissListener;
         mOnShowListener = builder.onShowListener;
+        mExactRectPortal = builder.exactRectPortal;
 
         init();
     }
@@ -177,7 +179,7 @@ public class SimpleTooltip implements PopupWindow.OnDismissListener {
     }
 
     private void createOverlay(final ViewGroup rootView) {
-        mOverlay = mTransparentOverlay ? new View(mContext) : new OverlayView(mContext, mAnchorView);
+        mOverlay = mTransparentOverlay ? new View(mContext) : new OverlayView(mContext, mAnchorView, mExactRectPortal);
         mOverlay.setLayoutParams(new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
         mOverlay.setOnTouchListener(mOverlayTouchListener);
         rootView.addView(mOverlay);
@@ -500,6 +502,7 @@ public class SimpleTooltip implements PopupWindow.OnDismissListener {
         private int animationPadding;
         private OnDismissListener onDismissListener;
         private OnShowListener onShowListener;
+        private boolean exactRectPortal;
         private long animationDuration;
         private int backgroundColor;
         private int textColor;
@@ -814,6 +817,11 @@ public class SimpleTooltip implements PopupWindow.OnDismissListener {
 
         public Builder onShowListener(OnShowListener onShowListener) {
             this.onShowListener = onShowListener;
+            return this;
+        }
+
+        public Builder exactRectPortal(boolean exactRectPortal) {
+            this.exactRectPortal = exactRectPortal;
             return this;
         }
     }

--- a/library/src/main/res/anim/popup_hide.xml
+++ b/library/src/main/res/anim/popup_hide.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <alpha android:fromAlpha="1" android:toAlpha="0" android:duration="200" />
+</set>

--- a/library/src/main/res/anim/popup_show.xml
+++ b/library/src/main/res/anim/popup_show.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <alpha android:fromAlpha="0" android:toAlpha="1" android:duration="200" />
+</set>

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -5,4 +5,9 @@
 
     </style>
 
+    <style name="popupAnimation">
+        <item name="android:windowEnterAnimation">@anim/popup_show</item>
+        <item name="android:windowExitAnimation">@anim/popup_hide</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
I have patched my fork to compile with v24 of the appcompat libraries and found that AppCompatPopupWindow is no longer public so cannot be accessed from class SimpleTooltip.

I took out explicit references and just used PopupWindow, which seems to work for me fine with Kitkat, Mashmallow and Nougat. Changes are here along with some other minor modifications that improved things for me.
