### PR TITLE
Fixing crash in OverlayView when bitmap has already been recycled.

### DIFF
--- a/library/src/main/java/io/github/douglasjunior/androidSimpleTooltip/OverlayView.java
+++ b/library/src/main/java/io/github/douglasjunior/androidSimpleTooltip/OverlayView.java
@@ -66,8 +66,9 @@ public class OverlayView extends View {
     protected void dispatchDraw(Canvas canvas) {
         if (invalidated || bitmap == null || bitmap.isRecycled())
             createWindowFrame();
-
-        canvas.drawBitmap(bitmap, 0, 0, null);
+        // The bitmap is checked again because of Android memory cleanup behavior. (See #42)
+        if (bitmap != null && !bitmap.isRecycled())
+            canvas.drawBitmap(bitmap, 0, 0, null);
     }
 
     private void createWindowFrame() {

--- a/library/src/main/java/io/github/douglasjunior/androidSimpleTooltip/OverlayView.java
+++ b/library/src/main/java/io/github/douglasjunior/androidSimpleTooltip/OverlayView.java
@@ -64,7 +64,7 @@ public class OverlayView extends View {
 
     @Override
     protected void dispatchDraw(Canvas canvas) {
-        if (invalidated)
+        if (invalidated || bitmap == null || bitmap.isRecycled())
             createWindowFrame();
 
         canvas.drawBitmap(bitmap, 0, 0, null);


### PR DESCRIPTION
Fixes #42 .