### PR TITLE
Add option to ignore overlay

### DIFF
--- a/library/src/main/java/io/github/douglasjunior/androidSimpleTooltip/SimpleTooltip.java
+++ b/library/src/main/java/io/github/douglasjunior/androidSimpleTooltip/SimpleTooltip.java
@@ -120,6 +120,7 @@ public class SimpleTooltip implements PopupWindow.OnDismissListener {
     private int mHighlightShape = OverlayView.HIGHLIGHT_SHAPE_OVAL;
     private int width = ViewGroup.LayoutParams.WRAP_CONTENT;
     private int height = ViewGroup.LayoutParams.WRAP_CONTENT;
+    private boolean ignoreOverlay = false;
 
 
     private SimpleTooltip(Builder builder) {
@@ -216,11 +217,14 @@ public class SimpleTooltip implements PopupWindow.OnDismissListener {
     }
 
     private void createOverlay() {
+        if (ignoreOverlay) {
+            return;
+        }
         mOverlay = mTransparentOverlay ? new View(mContext) : new OverlayView(mContext, mAnchorView, mHighlightShape, mOverlayOffset);
         if (mOverlayMatchParent)
-            mOverlay.setLayoutParams(new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
+            mOverlay.setLayoutParams(new ViewGroup.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT));
         else
-            mOverlay.setLayoutParams(new ViewGroup.LayoutParams(mRootView.getWidth(), mRootView.getHeight()));
+            mOverlay.setLayoutParams(new ViewGroup.LayoutParams(200, 200));
         mOverlay.setOnTouchListener(mOverlayTouchListener);
         mRootView.addView(mOverlay);
     }
@@ -567,6 +571,7 @@ public class SimpleTooltip implements PopupWindow.OnDismissListener {
         private int highlightShape = OverlayView.HIGHLIGHT_SHAPE_OVAL;
         private int width = ViewGroup.LayoutParams.WRAP_CONTENT;
         private int height = ViewGroup.LayoutParams.WRAP_CONTENT;
+        private boolean ignoreOverlay = false;
 
         public Builder(Context context) {
             this.context = context;
@@ -1079,6 +1084,16 @@ public class SimpleTooltip implements PopupWindow.OnDismissListener {
          */
         public Builder overlayMatchParent(boolean overlayMatchParent) {
             this.overlayMatchParent = overlayMatchParent;
+            return this;
+        }
+
+        /**
+         * As some dialogs have a problem when displaying tooltip (like expand/subtract) container, this ignores overlay adding altogether.
+         * @param ignoreOverlay flag to ignore overlay adding
+         * @return this
+         */
+        public Builder ignoreOverlay(boolean ignoreOverlay) {
+            this.ignoreOverlay = ignoreOverlay;
             return this;
         }
     }

--- a/library/src/main/java/io/github/douglasjunior/androidSimpleTooltip/SimpleTooltip.java
+++ b/library/src/main/java/io/github/douglasjunior/androidSimpleTooltip/SimpleTooltip.java
@@ -120,7 +120,7 @@ public class SimpleTooltip implements PopupWindow.OnDismissListener {
     private int mHighlightShape = OverlayView.HIGHLIGHT_SHAPE_OVAL;
     private int width = ViewGroup.LayoutParams.WRAP_CONTENT;
     private int height = ViewGroup.LayoutParams.WRAP_CONTENT;
-    private boolean ignoreOverlay = false;
+    private boolean mIgnoreOverlay;
 
 
     private SimpleTooltip(Builder builder) {
@@ -152,6 +152,7 @@ public class SimpleTooltip implements PopupWindow.OnDismissListener {
         mFocusable = builder.focusable;
         mRootView = SimpleTooltipUtils.findFrameLayout(mAnchorView);
         mHighlightShape = builder.highlightShape;
+        mIgnoreOverlay = builder.ignoreOverlay;
         this.width = builder.width;
         this.height = builder.height;
         init();
@@ -217,7 +218,7 @@ public class SimpleTooltip implements PopupWindow.OnDismissListener {
     }
 
     private void createOverlay() {
-        if (ignoreOverlay) {
+        if (mIgnoreOverlay) {
             return;
         }
         mOverlay = mTransparentOverlay ? new View(mContext) : new OverlayView(mContext, mAnchorView, mHighlightShape, mOverlayOffset);

--- a/library/src/main/java/io/github/douglasjunior/androidSimpleTooltip/SimpleTooltip.java
+++ b/library/src/main/java/io/github/douglasjunior/androidSimpleTooltip/SimpleTooltip.java
@@ -222,9 +222,9 @@ public class SimpleTooltip implements PopupWindow.OnDismissListener {
         }
         mOverlay = mTransparentOverlay ? new View(mContext) : new OverlayView(mContext, mAnchorView, mHighlightShape, mOverlayOffset);
         if (mOverlayMatchParent)
-            mOverlay.setLayoutParams(new ViewGroup.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT));
+            mOverlay.setLayoutParams(new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
         else
-            mOverlay.setLayoutParams(new ViewGroup.LayoutParams(200, 200));
+            mOverlay.setLayoutParams(new ViewGroup.LayoutParams(mRootView.getWidth(), mRootView.getHeight()));
         mOverlay.setOnTouchListener(mOverlayTouchListener);
         mRootView.addView(mOverlay);
     }


### PR DESCRIPTION
As i've also encountered issues described in here: https://github.com/douglasjunior/android-simple-tooltip/issues/50 , like changing width/height in dialog, i've added a value to ignore overlay altogether. 

Unfortunately, the in the app that i'm using this, have quite a bit of dialogs involved and this creates a problem when trying to display a tooltip. l