### PR TITLE
Fix setting dimens to match parent

### DIFF
--- a/library/src/main/java/io/github/douglasjunior/androidSimpleTooltip/SimpleTooltip.java
+++ b/library/src/main/java/io/github/douglasjunior/androidSimpleTooltip/SimpleTooltip.java
@@ -117,9 +117,9 @@ public class SimpleTooltip implements PopupWindow.OnDismissListener {
     private final float mArrowHeight;
     private final boolean mFocusable;
     private boolean dismissed = false;
-    private int mHighlightShape = OverlayView.HIGHLIGHT_SHAPE_OVAL;
-    private int width = ViewGroup.LayoutParams.WRAP_CONTENT;
-    private int height = ViewGroup.LayoutParams.WRAP_CONTENT;
+    private int mHighlightShape;
+    private int width;
+    private int height;
     private boolean mIgnoreOverlay;
 
 
@@ -166,8 +166,8 @@ public class SimpleTooltip implements PopupWindow.OnDismissListener {
     private void configPopupWindow() {
         mPopupWindow = new PopupWindow(mContext, null, mDefaultPopupWindowStyleRes);
         mPopupWindow.setOnDismissListener(this);
-        mPopupWindow.setWidth(ViewGroup.LayoutParams.WRAP_CONTENT);
-        mPopupWindow.setHeight(ViewGroup.LayoutParams.WRAP_CONTENT);
+        mPopupWindow.setWidth(width);
+        mPopupWindow.setHeight(height);
         mPopupWindow.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
         mPopupWindow.setOutsideTouchable(true);
         mPopupWindow.setTouchable(true);
@@ -307,7 +307,6 @@ public class SimpleTooltip implements PopupWindow.OnDismissListener {
             linearLayout.addView(mContentView);
         }
 
-//        LinearLayout.LayoutParams contentViewParams = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT, 0);
         LinearLayout.LayoutParams contentViewParams = new LinearLayout.LayoutParams(width, height, 0);
         contentViewParams.gravity = Gravity.CENTER;
         mContentView.setLayoutParams(contentViewParams);


### PR DESCRIPTION
Fixes #74. 

When setting the height or width of the `contentView` to `MatchParent`, the view would collapse since the root view (i.e. the `PopupWindow`) would have dimensions set to `WrapContent`, which would collapse down and give the `contentView` the same dimensions. The fix involved setting the dimensions of the `PopupWindow` to be the same as the dimensions of the `contentView`. 