### PR TITLE
modified dismiss listener functionlity to fire only on tip click if c…

### DIFF
--- a/library/src/main/java/io/github/douglasjunior/androidSimpleTooltip/SimpleTooltip.java
+++ b/library/src/main/java/io/github/douglasjunior/androidSimpleTooltip/SimpleTooltip.java
@@ -362,8 +362,15 @@ public class SimpleTooltip implements PopupWindow.OnDismissListener {
         mRootView = null;
         mOverlay = null;
 
-        if (mOnDismissListener != null && dismissedOnClick)
-            mOnDismissListener.onDismiss(this);
+        if (mOnDismissListener != null) {
+            if(mDismissOnInsideTouch){
+                if(dismissedOnClick){
+                    mOnDismissListener.onDismiss(this);
+                }
+            }else{
+                mOnDismissListener.onDismiss(this);
+            }
+        }
         mOnDismissListener = null;
         dismissedOnClick = false;
 

--- a/library/src/main/java/io/github/douglasjunior/androidSimpleTooltip/SimpleTooltip.java
+++ b/library/src/main/java/io/github/douglasjunior/androidSimpleTooltip/SimpleTooltip.java
@@ -116,7 +116,7 @@ public class SimpleTooltip implements PopupWindow.OnDismissListener {
     private final float mArrowWidth;
     private final float mArrowHeight;
     private final boolean mFocusable;
-    private boolean dismissed = false;
+    private boolean dismissed = false, dismissedOnClick;
     private int mHighlightShape;
     private int width;
     private int height;
@@ -183,6 +183,7 @@ public class SimpleTooltip implements PopupWindow.OnDismissListener {
                 } else if (!mDismissOnOutsideTouch && event.getAction() == MotionEvent.ACTION_OUTSIDE) {
                     return true;
                 } else if ((event.getAction() == MotionEvent.ACTION_DOWN) && mDismissOnInsideTouch) {
+                    dismissedOnClick = true;
                     dismiss();
                     return true;
                 }
@@ -361,9 +362,10 @@ public class SimpleTooltip implements PopupWindow.OnDismissListener {
         mRootView = null;
         mOverlay = null;
 
-        if (mOnDismissListener != null)
+        if (mOnDismissListener != null && dismissedOnClick)
             mOnDismissListener.onDismiss(this);
         mOnDismissListener = null;
+        dismissedOnClick = false;
 
         SimpleTooltipUtils.removeOnGlobalLayoutListener(mPopupWindow.getContentView(), mLocationLayoutListener);
         SimpleTooltipUtils.removeOnGlobalLayoutListener(mPopupWindow.getContentView(), mArrowLayoutListener);


### PR DESCRIPTION
For issue #80 
Introduced a boolean dismissOnClick which toggles to true on tip  inside click if hide on inside touch is enabled, this helps us to fire OnDismissListener only when tip is clicked not on explicit call to dismiss function.