### PR TITLE
Adds absorbing option on outside touch dismissal

### DIFF
--- a/sample/src/main/java/io/github/douglasjunior/androidSimpleTooltip/sample/MainActivity.java
+++ b/sample/src/main/java/io/github/douglasjunior/androidSimpleTooltip/sample/MainActivity.java
@@ -32,7 +32,6 @@ import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.view.Gravity;
 import android.view.View;
-import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.EditText;
 
@@ -64,6 +63,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         findViewById(R.id.btn_outside).setOnClickListener(this);
         findViewById(R.id.btn_inside).setOnClickListener(this);
         findViewById(R.id.btn_inside_modal).setOnClickListener(this);
+        findViewById(R.id.btn_absorb).setOnClickListener(this);
         findViewById(R.id.btn_modal_custom).setOnClickListener(this);
         findViewById(R.id.btn_no_arrow).setOnClickListener(this);
         findViewById(R.id.btn_custom_arrow).setOnClickListener(this);
@@ -261,6 +261,15 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
                     .transparentOverlay(false)
                     .highlightShape(OverlayView.HIGHLIGHT_SHAPE_RECTANGULAR)
                     .overlayOffset(0)
+                    .build()
+                    .show();
+        } else if (v.getId() == R.id.btn_absorb) {
+            new SimpleTooltip.Builder(this)
+                    .anchorView(v)
+                    .text(R.string.btn_absorb)
+                    .gravity(Gravity.TOP)
+                    .dismissOnOutsideTouch(true)
+                    .absorbOutsideTouch(true)
                     .build()
                     .show();
         }

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -120,6 +120,13 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="start"
                 android:text="@string/btn_overlay_rect" />
+
+            <Button
+                android:id="@+id/btn_absorb"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:text="@string/btn_absorb" />
         </LinearLayout>
     </ScrollView>
 

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="btn_inside">Click inside</string>
     <string name="btn_inside_modal">Click inside (Modal)</string>
     <string name="btn_modal_custom">Modal custom.</string>
+    <string name="btn_absorb">Absorb outside touch</string>
     <string name="btn_no_arrow">No arrow</string>
     <string name="btn_custom_arrow">Arrow custom.</string>
     <string name="btn_next">NEXT</string>


### PR DESCRIPTION
I have modified your superb tooltip library a little bit for my needs, in my particular use case I needed to dismiss the tooltip on outside touch and prevent the touch event from propagating to other underlying views.
Regards!
Jiri